### PR TITLE
Test for escaping of HTML chars in table

### DIFF
--- a/test.js
+++ b/test.js
@@ -362,6 +362,18 @@ test('mdast -> markdown', (t) => {
 
   t.deepEqual(
     toMarkdown(
+      {
+        type: 'tableCell',
+        children: [{type: 'text', value: '<a b>'}]
+      },
+      {extensions: [gfmTableToMarkdown()]}
+    ),
+    '&lt;a b&gt;\n',
+    'should escape html chars'
+  )
+
+  t.deepEqual(
+    toMarkdown(
       {type: 'tableCell', children: [{type: 'inlineCode', value: 'a\\b'}]},
       {extensions: [gfmTableToMarkdown()]}
     ),


### PR DESCRIPTION
<!--
  Please check the needed checkboxes ([ ] -> [x]). Leave the
  comments as they are, they won’t show on GitHub.
  We are excited about pull requests, but please try to limit the scope, provide
  a general description of the changes, and remember, it’s up to you to convince
  us to land it.
-->

### Initial checklist

*   [x] I read the support docs <!-- https://github.com/syntax-tree/.github/blob/main/support.md -->
*   [x] I read the contributing guide <!-- https://github.com/syntax-tree/.github/blob/main/contributing.md -->
*   [x] I agree to follow the code of conduct <!-- https://github.com/syntax-tree/.github/blob/main/code-of-conduct.md -->
*   [x] I searched issues and couldn’t find anything (or linked relevant results below) <!-- https://github.com/search?q=user%3Asyntax-tree&type=Issues -->
*   [x] If applicable, I’ve added docs and tests

### Description of changes

Hello 👋 

I'm investigating an issue where the formatting to markdown doesn't escape HTML chars in a table cell.

I'm still new to contribute to remark/mdast/etc, this PR is only started with a failing test till I deep dive more into the issue.

For example, considering the following table:

```markdown
| A | B |
| :--- | :--- |
| C | &lt;D E&gt; |
```

it's parsed as the following table cell:

```json
{
    "type": "tableCell",
    "children": [
        {
            "type": "text",
            "value": "<D E>"
        }
    ],
    ...
}
```

which then using `remark-stringily` (and this module under it), output:

```
| A | B |
| :--- | :--- |
| C | <D E> |
```

💥 which crash at parsing because `<D E>` is not recognised as HTML.

<!--do not edit: pr-->
