### PR TITLE
Add missing dependency for types

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,13 +37,14 @@
     "index.js"
   ],
   "dependencies": {
+    "@types/mdast": "^3.0.0",
     "markdown-table": "^3.0.0",
+    "mdast-util-from-markdown": "^1.0.0",
     "mdast-util-to-markdown": "^1.3.0"
   },
   "devDependencies": {
     "@types/tape": "^4.0.0",
     "c8": "^7.0.0",
-    "mdast-util-from-markdown": "^1.0.0",
     "micromark-extension-gfm-table": "^1.0.0",
     "prettier": "^2.0.0",
     "remark-cli": "^10.0.0",


### PR DESCRIPTION
<!--
  Please check the needed checkboxes ([ ] -> [x]). Leave the
  comments as they are, they won’t show on GitHub.
  We are excited about pull requests, but please try to limit the scope, provide
  a general description of the changes, and remember, it’s up to you to convince
  us to land it.
-->

### Initial checklist

*   [x] I read the support docs <!-- https://github.com/syntax-tree/.github/blob/main/support.md -->
*   [x] I read the contributing guide <!-- https://github.com/syntax-tree/.github/blob/main/contributing.md -->
*   [x] I agree to follow the code of conduct <!-- https://github.com/syntax-tree/.github/blob/main/code-of-conduct.md -->
*   [x] I searched issues and couldn’t find anything (or linked relevant results below) <!-- https://github.com/search?q=user%3Asyntax-tree&type=Issues -->
*   [x] If applicable, I’ve added docs and tests

### Description of changes

Fix these type errors:

```
ERROR in ../../.yarn/cache/mdast-util-gfm-table-npm-1.0.3-e785b8b0a4-f310f06a57.zip/node_modules/mdast-util-gfm-table/index.d.ts 10:32-39
TS2307: Cannot find module 'mdast' or its corresponding type declarations.
     8 | /** @type {FromMarkdownExtension} */
     9 | export const gfmTableFromMarkdown: FromMarkdownExtension
  > 10 | export type AlignType = import('mdast').AlignType
       |                                ^^^^^^^
    11 | export type Table = import('mdast').Table
    12 | export type TableRow = import('mdast').TableRow
    13 | export type TableCell = import('mdast').TableCell

ERROR in ../../.yarn/cache/mdast-util-gfm-table-npm-1.0.3-e785b8b0a4-f310f06a57.zip/node_modules/mdast-util-gfm-table/index.d.ts 11:28-35
TS2307: Cannot find module 'mdast' or its corresponding type declarations.
     9 | export const gfmTableFromMarkdown: FromMarkdownExtension
    10 | export type AlignType = import('mdast').AlignType
  > 11 | export type Table = import('mdast').Table
       |                            ^^^^^^^
    12 | export type TableRow = import('mdast').TableRow
    13 | export type TableCell = import('mdast').TableCell
    14 | export type InlineCode = import('mdast').InlineCode

ERROR in ../../.yarn/cache/mdast-util-gfm-table-npm-1.0.3-e785b8b0a4-f310f06a57.zip/node_modules/mdast-util-gfm-table/index.d.ts 12:31-38
TS2307: Cannot find module 'mdast' or its corresponding type declarations.
    10 | export type AlignType = import('mdast').AlignType
    11 | export type Table = import('mdast').Table
  > 12 | export type TableRow = import('mdast').TableRow
       |                               ^^^^^^^
    13 | export type TableCell = import('mdast').TableCell
    14 | export type InlineCode = import('mdast').InlineCode
    15 | export type MarkdownTableOptions = import('markdown-table').MarkdownTableOptions

ERROR in ../../.yarn/cache/mdast-util-gfm-table-npm-1.0.3-e785b8b0a4-f310f06a57.zip/node_modules/mdast-util-gfm-table/index.d.ts 13:32-39
TS2307: Cannot find module 'mdast' or its corresponding type declarations.
    11 | export type Table = import('mdast').Table
    12 | export type TableRow = import('mdast').TableRow
  > 13 | export type TableCell = import('mdast').TableCell
       |                                ^^^^^^^
    14 | export type InlineCode = import('mdast').InlineCode
    15 | export type MarkdownTableOptions = import('markdown-table').MarkdownTableOptions
    16 | export type FromMarkdownExtension = import('mdast-util-from-markdown').Extension

ERROR in ../../.yarn/cache/mdast-util-gfm-table-npm-1.0.3-e785b8b0a4-f310f06a57.zip/node_modules/mdast-util-gfm-table/index.d.ts 14:33-40
TS2307: Cannot find module 'mdast' or its corresponding type declarations.
    12 | export type TableRow = import('mdast').TableRow
    13 | export type TableCell = import('mdast').TableCell
  > 14 | export type InlineCode = import('mdast').InlineCode
       |                                 ^^^^^^^
    15 | export type MarkdownTableOptions = import('markdown-table').MarkdownTableOptions
    16 | export type FromMarkdownExtension = import('mdast-util-from-markdown').Extension
    17 | export type FromMarkdownHandle = import('mdast-util-from-markdown').Handle

ERROR in ../../.yarn/cache/mdast-util-gfm-table-npm-1.0.3-e785b8b0a4-f310f06a57.zip/node_modules/mdast-util-gfm-table/index.d.ts 16:44-70
TS2307: Cannot find module 'mdast-util-from-markdown' or its corresponding type declarations.
    14 | export type InlineCode = import('mdast').InlineCode
    15 | export type MarkdownTableOptions = import('markdown-table').MarkdownTableOptions
  > 16 | export type FromMarkdownExtension = import('mdast-util-from-markdown').Extension
       |                                            ^^^^^^^^^^^^^^^^^^^^^^^^^^
    17 | export type FromMarkdownHandle = import('mdast-util-from-markdown').Handle
    18 | export type ToMarkdownExtension = import('mdast-util-to-markdown').Options
    19 | export type ToMarkdownHandle = import('mdast-util-to-markdown').Handle

ERROR in ../../.yarn/cache/mdast-util-gfm-table-npm-1.0.3-e785b8b0a4-f310f06a57.zip/node_modules/mdast-util-gfm-table/index.d.ts 17:41-67
TS2307: Cannot find module 'mdast-util-from-markdown' or its corresponding type declarations.
    15 | export type MarkdownTableOptions = import('markdown-table').MarkdownTableOptions
    16 | export type FromMarkdownExtension = import('mdast-util-from-markdown').Extension
  > 17 | export type FromMarkdownHandle = import('mdast-util-from-markdown').Handle
       |                                         ^^^^^^^^^^^^^^^^^^^^^^^^^^
    18 | export type ToMarkdownExtension = import('mdast-util-to-markdown').Options
    19 | export type ToMarkdownHandle = import('mdast-util-to-markdown').Handle
    20 | export type ToMarkdownContext = import('mdast-util-to-markdown').Context
```

<!--do not edit: pr-->
