### PR TITLE
Add missing types dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,12 +38,12 @@
     "index.js"
   ],
   "dependencies": {
+    "@types/mdast": "^3.0.0",
     "markdown-table": "^3.0.0",
     "mdast-util-from-markdown": "^1.0.0",
     "mdast-util-to-markdown": "^1.3.0"
   },
   "devDependencies": {
-    "@types/mdast": "^3.0.0",
     "@types/tape": "^4.0.0",
     "c8": "^7.0.0",
     "micromark-extension-gfm-table": "^1.0.0",


### PR DESCRIPTION
<!--
  Please check the needed checkboxes ([ ] -> [x]). Leave the
  comments as they are, they won’t show on GitHub.
  We are excited about pull requests, but please try to limit the scope, provide
  a general description of the changes, and remember, it’s up to you to convince
  us to land it.
-->

### Initial checklist

*   [x] I read the support docs <!-- https://github.com/syntax-tree/.github/blob/main/support.md -->
*   [x] I read the contributing guide <!-- https://github.com/syntax-tree/.github/blob/main/contributing.md -->
*   [x] I agree to follow the code of conduct <!-- https://github.com/syntax-tree/.github/blob/main/code-of-conduct.md -->
*   [x] I searched issues and couldn’t find anything (or linked relevant results below) <!-- https://github.com/search?q=user%3Asyntax-tree&type=Issues -->
*   [x] If applicable, I’ve added docs and tests

### Description of changes

This PR moves `@types/mdast` back to dependencies since the declaration files still reference them. This was initially done in https://github.com/syntax-tree/mdast-util-gfm-table/pull/2, but then moved to a devDependency in https://github.com/syntax-tree/mdast-util-gfm-table/commit/c7c917851937251be18e5ddb547b49625fdad408. `@types/mdast` still needs to be listed as a dependency since `@types/mdast` is still referenced in the generated `lib/index.d.ts` file. 

<!--do not edit: pr-->
