### PR TITLE
Bug fix: Add optional chain for inTable check

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -120,7 +120,7 @@ function enterCell(token) {
 function exitCodeText(token) {
   let value = this.resume()
 
-  if (this.data.inTable) {
+  if (this.data?.inTable) {
     value = value.replace(/\\([\\|])/g, replace)
   }
 


### PR DESCRIPTION
<!--
  Please check the needed checkboxes ([ ] -> [x]).
  Leave the comments as they are: they do not show on GitHub.

  Please try to limit the scope,
  provide a general description of the changes,
  and remember it’s up to you to convince us to land it.

  We are excited about pull requests.
  Thank you!
-->

### Initial checklist

* [x] I read the support docs <!-- https://github.com/syntax-tree/.github/blob/main/support.md -->
* [x] I read the contributing guide <!-- https://github.com/syntax-tree/.github/blob/main/contributing.md -->
* [x] I agree to follow the code of conduct <!-- https://github.com/syntax-tree/.github/blob/main/code-of-conduct.md -->
* [x] I searched issues and discussions and couldn’t find anything or linked relevant results below <!-- https://github.com/search?q=user%3Asyntax-tree&type=issues and https://github.com/orgs/syntax-tree/discussions -->
* [x] I made sure the docs are up to date
* [x] I included tests (or that’s not needed)

### Description of changes

Add optional chain in `exitCodeText` `this.data.inTable` check because `this.data` is sometimes undefined. I will admit I have not pulled the thread on why this.data is sometimes undefined. This is likely a problem higher up the food chain (in my case Vinxi build (with SolidStart) -> solid-jsx -> MDX so I understand if it is not desirable to include this change here. Nonetheless, it would be nice to have this fail without halting the entire build process as everything else appears to be working fine. Currently I am monkey-patching this character in to achieve successful builds.

<!--do not edit: pr-->
