### PR TITLE
perf: pre-declare position on table factories

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -230,11 +230,8 @@ export function gfmTableToMarkdown(options) {
   function serializeData(matrix, align) {
     return markdownTable(matrix, {
       align,
-      // @ts-expect-error: `markdown-table` types should support `null`.
       alignDelimiters,
-      // @ts-expect-error: `markdown-table` types should support `null`.
       padding,
-      // @ts-expect-error: `markdown-table` types should support `null`.
       stringLength
     })
   }

--- a/lib/index.js
+++ b/lib/index.js
@@ -65,13 +65,17 @@ export function gfmTableFromMarkdown() {
 function enterTable(token) {
   const align = token._align
   assert(align, 'expected `_align` on table')
+  // Trailing `position: undefined` keeps the table hidden class stable;
+  // mdast-util-from-markdown's enter() patches the field to a real value
+  // but the property already exists, so no shape transition fires.
   this.enter(
     {
       type: 'table',
       align: align.map(function (d) {
         return d === 'none' ? null : d
       }),
-      children: []
+      children: [],
+      position: undefined
     },
     token
   )
@@ -92,7 +96,8 @@ function exitTable(token) {
  * @type {FromMarkdownHandle}
  */
 function enterRow(token) {
-  this.enter({type: 'tableRow', children: []}, token)
+  // See enterTable above for the rationale on the trailing position field.
+  this.enter({type: 'tableRow', children: [], position: undefined}, token)
 }
 
 /**
@@ -108,7 +113,8 @@ function exit(token) {
  * @type {FromMarkdownHandle}
  */
 function enterCell(token) {
-  this.enter({type: 'tableCell', children: []}, token)
+  // See enterTable above for the rationale on the trailing position field.
+  this.enter({type: 'tableCell', children: [], position: undefined}, token)
 }
 
 // Overwrite the default code text data handler to unescape escaped pipes when


### PR DESCRIPTION
<!--
  Please check the needed checkboxes ([ ] -> [x]).
  Leave the comments as they are: they do not show on GitHub.

  Please try to limit the scope,
  provide a general description of the changes,
  and remember it’s up to you to convince us to land it.

  We are excited about pull requests.
  Thank you!
-->

### Initial checklist

* [x] I read the support docs <!-- https://github.com/syntax-tree/.github/blob/main/support.md -->
* [x] I read the contributing guide <!-- https://github.com/syntax-tree/.github/blob/main/contributing.md -->
* [x] I agree to follow the code of conduct <!-- https://github.com/syntax-tree/.github/blob/main/code-of-conduct.md -->
* [x] I searched issues and discussions and couldn’t find anything or linked relevant results below <!-- https://github.com/search?q=user%3Asyntax-tree&type=issues and https://github.com/orgs/syntax-tree/discussions -->
* [x] I made sure the docs are up to date
* [x] I included tests (or that’s not needed)

### Description of changes

Problem: the table handlers build table, tableRow, and tableCell
nodes as fresh literals, then mdast-util-from-markdown's enter() sets
node.position afterwards. V8 treats the late assignment as a shape
change, so each node walks through two hidden classes instead of one.
Core nodes already avoid this by declaring position up front;
extension nodes leave the tree with mixed layouts.

Goal: declare position on all three factory literals at construction
so V8 keeps a single hidden class per node type.

Changes:
- lib/index.js: trailing position: undefined on the table literal in
  enterTable.
- lib/index.js: trailing position: undefined on the tableRow literal
  in enterRow.
- lib/index.js: trailing position: undefined on the tableCell literal
  in enterCell.

Notes: pairs with the matching core change in
https://github.com/syntax-tree/mdast-util-from-markdown/pull/53;
merged on its own this branch is a no-op. Validated with npm test
(build, format, 100% coverage, 32 of 32 tests in dev and prod).

The branch also includes a small chore commit at lib/index.js:233
through 237 that drops three @ts-expect-error directives that no
longer match the current markdown-table types and that fail tsc on
upstream main as written. Without that cleanup the package's own test
script does not pass, so the chore commit is required to land before
this one. Squash or split per maintainer preference.

Bench (local harness, 3-run median-of-medians, GFM tokenizer and
mdast extensions stacked). Numbers below are the parse time delta
versus an unmodified upstream main; positive numbers mean slower,
negative numbers mean faster.

Inputs: a 4-column 1000-row table and a 20-column 100-row table.
Tables sit at low mdast-layer ratios on the baseline (1.08 and 1.09
respectively); the bottleneck for tables is in
micromark-extension-gfm-table, not in this util. Numbers should be
read as "no regression" rather than "credible win."

Effect of pairing this branch with PR #53:

- 4 cols x 1000 rows:
  PR #53 alone: 4.7 percent slower.
  PR #53 with this branch alongside: 6.2 percent slower.
- 20 cols x 100 rows:
  PR #53 alone: 5.0 percent slower.
  PR #53 with this branch alongside: 7.2 percent slower.

Both rows sit inside the machine's drift band of 4 to 12 percent
(main vs main with no code change in the same window). Pairing
neither helps nor hurts table parses meaningfully, which matches what
the baseline ratio predicts. The branch is included for shape
consistency across the GFM stack rather than for a measurable
per-table win.

<!--do not edit: pr-->
